### PR TITLE
Blank states

### DIFF
--- a/src/a-to-z/style.scss
+++ b/src/a-to-z/style.scss
@@ -96,7 +96,7 @@ label {
 	flex-wrap: wrap;
 	justify-content: center;
 	min-height: 105px;
-	padding: 10px 0;
+	padding: 10px 5px 10px;
 	background: #fff;
 	border-bottom: 4px solid var(--wp--preset--color--orange);
 	z-index: 1;
@@ -158,6 +158,35 @@ button.a-to-z-index-alphabet-letter-button {
 	.a-to-z-index-sections {
 		margin: 80px auto 0;
 	}
+}
+
+.a-to-z-index-no-results {
+	padding: 40px 20px;
+}
+
+@media screen and (min-width: 600px) {
+	.a-to-z-index-no-results {
+		padding: 60px 20px;
+	}
+}
+
+.a-to-z-index-no-results-content {
+	max-width: 750px;
+  margin: 0 auto;
+	text-align: center;
+  
+  h2 {
+		margin: 0;
+    font-weight: var(--wp--custom--font-weight--black);
+    line-height: var(--wp--custom--line-height--heading);
+  }	
+}
+
+.a-to-z-index-no-results-footer {
+	max-width: var(--wp--style--global--content-size);
+	margin: 40px auto 0;
+	padding: 20px 0 0;
+	border-top: 1px solid var(--wp--preset--color--gray-2);
 }
 
 .a-to-z-index-section {

--- a/src/a-to-z/style.scss
+++ b/src/a-to-z/style.scss
@@ -22,6 +22,7 @@ $input-padding-x: 15px;
 @import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/root";
 @import "~bootstrap/scss/forms";
+@import "~bootstrap/scss/placeholders";
 
 // MOVE TO UTKWDS
 
@@ -58,6 +59,15 @@ label {
     }
 }
 
+.placeholder {
+	color: #d9d9d9 !important;
+	border-radius: 4px;
+
+	&-lg {
+    min-height: 32px;
+  }
+}
+
 .a-to-z-container-banner {
 	height: 200px;
 }
@@ -81,20 +91,25 @@ label {
 }
 
 .a-to-z-index-alphabet {
-	position: sticky;
 	top: 0;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: center;
+	min-height: 105px;
 	padding: 10px 0;
 	background: #fff;
 	border-bottom: 4px solid var(--wp--preset--color--orange);
 	z-index: 1;
+
+	&--fixed {
+		position: sticky;
+	}
 }
 
 @media screen and (min-width: 600px) {
   .a-to-z-index-alphabet {
-    padding: 25px 0 30px 0;
+		gap: 10px;
+    padding: 25px 10px 30px;
 		border-bottom: none;
 
 		.admin-bar & {
@@ -117,11 +132,10 @@ label {
 	font-weight: var(--wp--custom--font-weight--medium);
 	color: var(--wp--custom--color--river);
 	text-decoration: underline;
-	background-color: unset;
 	border: none;
 	border-radius: 4px;
 	text-decoration-thickness: auto !important;
-	
+
 	&.a-to-z-index-alphabet-letter-button--active,
 	&:active,
 	&:hover {
@@ -129,6 +143,10 @@ label {
 		text-decoration: none;
     background-color: var(--wp--custom--color--river);
 	}
+}
+
+button.a-to-z-index-alphabet-letter-button {
+	background-color: unset;
 }
 
 .a-to-z-index-sections {

--- a/src/a-to-z/view.js
+++ b/src/a-to-z/view.js
@@ -5,10 +5,12 @@ import { createRoot } from 'react-dom/client';
 export default function View() {
     const alphabetRef = useRef(null);
     const sectionRefs = useRef({});
+    const [isLoading, setIsLoading] = useState(true);
     const [aToZItems, setAToZItems] = useState([]);
     const [searchTerm, setSearchTerm] = useState(new URLSearchParams(window.location.search).get('search') || '');
     const [isBackToVisible, setIsBackToVisible] = useState(false);
     const [activeLetter, setActiveLetter] = useState(null);
+    const [isSticky, setIsSticky] = useState(false);
     const [offset, setOffset] = useState(0);
     const [debouncedSearch, setDebouncedSearch] = useState(searchTerm);
 
@@ -46,6 +48,8 @@ export default function View() {
             setAToZItems(data);
         } catch (error) {
             console.error('Failed to fetch A to Z items:', error);
+        } finally {
+            setIsLoading(false);
         }
     };
 
@@ -108,16 +112,6 @@ export default function View() {
         return () => observer.disconnect();
     }, [aToZItems]);
 
-    // Show back to top element
-    useEffect(() => {
-        const toggleVisibility = () => {
-            setIsBackToVisible(window.scrollY > 1200);
-        };
-
-        window.addEventListener("scroll", toggleVisibility);
-        return () => window.removeEventListener("scroll", toggleVisibility);
-    }, []);
-
     const scrollToElement = () => {
         const element = document.getElementById("alpha");
         if (element) {
@@ -127,6 +121,25 @@ export default function View() {
             });
         }
     };
+
+    useEffect(() => {
+        const handleScroll = () => {
+            // Back to top visibility
+            setIsBackToVisible(window.scrollY > 1200);
+    
+            // Sticky alphabet
+            if (alphabetRef.current) {
+                const adminBar = document.getElementById("wpadminbar");
+                const rect = alphabetRef.current.getBoundingClientRect();
+                let offset = adminBar ? adminBar.offsetHeight : 0;
+    
+                setIsSticky(rect.top <= offset);
+            }
+        };
+    
+        window.addEventListener("scroll", handleScroll);
+        return () => window.removeEventListener("scroll", handleScroll);
+    }, []);
 
     const scrollToSection = (letter) => {
         const section = sectionRefs.current[letter]?.current;
@@ -156,35 +169,66 @@ export default function View() {
                             <label for="program-search">Search the index</label>
                         </div>
                     </div>
-                    <div className="a-to-z-index-alphabet" ref={alphabetRef}>
-                        {aToZItems.map((group) => (
-                            <div className="a-to-z-index-alphabet-letter" key={group.letter}>
-                                <button
-                                    // href={`#${group.letter}`}
-                                    className={`a-to-z-index-alphabet-letter-button ${activeLetter === group.letter && "a-to-z-index-alphabet-letter-button--active"
-                                        }`}
-                                    onClick={() => scrollToSection(group.letter)}
-                                >{group.letter}</button>
-                            </div>
-                        ))}
+                    <div className={`a-to-z-index-alphabet${isSticky ? " a-to-z-index-alphabet--fixed" : ""}`} ref={alphabetRef}>
+                        {isLoading ? (
+                            [...Array(20)].map(() => (
+                                <div class="placeholder-glow">
+                                    <span class="a-to-z-index-alphabet-letter-button placeholder"></span>
+                                </div>
+                            ))
+                        ) : (
+                            aToZItems.map((group) => (
+                                <div className="a-to-z-index-alphabet-letter" key={group.letter}>
+                                    <button
+                                        // href={`#${group.letter}`}
+                                        className={`a-to-z-index-alphabet-letter-button ${activeLetter === group.letter && "a-to-z-index-alphabet-letter-button--active"
+                                            }`}
+                                        onClick={() => scrollToSection(group.letter)}
+                                    >{group.letter}</button>
+                                </div>
+                            ))
+                        )}
                     </div>
                     <div className="a-to-z-index-sections">
-                        {aToZItems.map((group) => (
-                            <div key={group.letter} id={group.letter} className="a-to-z-index-section" ref={sectionRefs.current[group.letter]}>
-                                <div className="a-to-z-index-section-drop-cap">
-                                    <div className="a-to-z-index-section-drop-cap-letter">{group.letter}</div>
+                        {isLoading ? (
+                            [...Array(2)].map((e, i) => (
+                                <div key={i} className="a-to-z-index-section">
+                                    <div className="a-to-z-index-section-drop-cap">
+                                        <div className="a-to-z-index-section-drop-cap-letter placeholder-glow">
+                                            <span className="placeholder" style={{ width: 100 }}></span>
+                                        </div>
+                                    </div>
+                                    <div className="a-to-z-index-section-content">
+                                        <ul className="a-to-z-index-section-list">
+                                            {[...Array(5)].map((e, i) => (
+                                                <li key={i} className="a-to-z-index-section-list-item placeholder-glow">
+                                                    <a className="placeholder placeholder-lg" style={{ width: `100%` }}></a>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
                                 </div>
-                                <div className="a-to-z-index-section-content">
-                                    <ul className="a-to-z-index-section-list">
-                                        {group.posts.map((item) => (
-                                            <li key={item.ID} className="a-to-z-index-section-list-item">
-                                                <a href={item.url}>{item.title}</a><br />
-                                            </li>
-                                        ))}
-                                    </ul>
+                            ))
+                        ) : aToZItems.length === 0 && !isLoading ? (
+                            <p>No results</p>
+                        ) : (
+                            aToZItems.map((group) => (
+                                <div key={group.letter} id={group.letter} className="a-to-z-index-section" ref={sectionRefs.current[group.letter]}>
+                                    <div className="a-to-z-index-section-drop-cap">
+                                        <div className="a-to-z-index-section-drop-cap-letter">{group.letter}</div>
+                                    </div>
+                                    <div className="a-to-z-index-section-content">
+                                        <ul className="a-to-z-index-section-list">
+                                            {group.posts.map((item) => (
+                                                <li key={item.ID} className="a-to-z-index-section-list-item">
+                                                    <a href={item.url}>{item.title}</a>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </div>
                                 </div>
-                            </div>
-                        ))}
+                            ))
+                        )}
                     </div>
                     {isBackToVisible && (
                         <button className="a-to-z-index-back-to" onClick={scrollToElement}>

--- a/src/a-to-z/view.js
+++ b/src/a-to-z/view.js
@@ -78,16 +78,16 @@ export default function View() {
     });
 
     useEffect(() => {
-        if (alphabetRef.current) {
-            const adminBar = document.getElementById('wpadminbar');
-            let adminBarOffset = 0;
+        if (!alphabetRef.current) return;
 
-            if (adminBar && window.innerWidth > 600) {
-                adminBarOffset = adminBar.offsetHeight;
-            }
+        const adminBar = document.getElementById('wpadminbar');
+        let adminBarOffset = 0;
 
-            setOffset(alphabetRef.current.offsetHeight + adminBarOffset);
+        if (adminBar && window.innerWidth > 600) {
+            adminBarOffset = adminBar.offsetHeight;
         }
+
+        setOffset(alphabetRef.current.offsetHeight + adminBarOffset);
 
         const observerOptions = {
             root: null,
@@ -169,15 +169,19 @@ export default function View() {
                             <label for="program-search">Search the index</label>
                         </div>
                     </div>
-                    <div className={`a-to-z-index-alphabet${isSticky ? " a-to-z-index-alphabet--fixed" : ""}`} ref={alphabetRef}>
-                        {isLoading ? (
-                            [...Array(20)].map(() => (
+                    {isLoading ? (
+                        <div className="a-to-z-index-alphabet">
+                            {[...Array(20)].map(() => (
                                 <div class="placeholder-glow">
                                     <span class="a-to-z-index-alphabet-letter-button placeholder"></span>
                                 </div>
-                            ))
-                        ) : (
-                            aToZItems.map((group) => (
+                            ))}
+                        </div>
+                    ) : aToZItems.length === 0 && !isLoading ? (
+                        <></>
+                    ) : (
+                        <div className={`a-to-z-index-alphabet${isSticky ? " a-to-z-index-alphabet--fixed" : ""}`} ref={alphabetRef}>
+                            {aToZItems.map((group) => (
                                 <div className="a-to-z-index-alphabet-letter" key={group.letter}>
                                     <button
                                         // href={`#${group.letter}`}
@@ -186,12 +190,12 @@ export default function View() {
                                         onClick={() => scrollToSection(group.letter)}
                                     >{group.letter}</button>
                                 </div>
-                            ))
-                        )}
-                    </div>
-                    <div className="a-to-z-index-sections">
-                        {isLoading ? (
-                            [...Array(2)].map((e, i) => (
+                            ))}
+                        </div>
+                    )}
+                    {isLoading ? (
+                        <div className="a-to-z-index-sections">
+                            {[...Array(2)].map((e, i) => (
                                 <div key={i} className="a-to-z-index-section">
                                     <div className="a-to-z-index-section-drop-cap">
                                         <div className="a-to-z-index-section-drop-cap-letter placeholder-glow">
@@ -208,11 +212,26 @@ export default function View() {
                                         </ul>
                                     </div>
                                 </div>
-                            ))
-                        ) : aToZItems.length === 0 && !isLoading ? (
-                            <p>No results</p>
-                        ) : (
-                            aToZItems.map((group) => (
+                            ))}
+                        </div>
+                    ) : aToZItems.length === 0 && !isLoading ? (
+                        <div className="a-to-z-index-no-results">
+                            <div className="a-to-z-index-no-results-content">
+                                <h2>There are no matches for your search.</h2>
+                                <p>Try searching again with different terms.</p>
+                                <p class="is-style-utkwds-cta-link">
+                                    <a href="https://www.utk.edu/">Search all of utk.edu</a>
+                                </p>
+                            </div>
+                            <div className="a-to-z-index-no-results-footer">
+                                <p class="is-style-utkwds-cta-link">
+                                    <a href="https://communications.utk.edu/a-z-index-update-request/">Request an update to the index</a>
+                                </p>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="a-to-z-index-sections">
+                            {aToZItems.map((group) => (
                                 <div key={group.letter} id={group.letter} className="a-to-z-index-section" ref={sectionRefs.current[group.letter]}>
                                     <div className="a-to-z-index-section-drop-cap">
                                         <div className="a-to-z-index-section-drop-cap-letter">{group.letter}</div>
@@ -227,9 +246,9 @@ export default function View() {
                                         </ul>
                                     </div>
                                 </div>
-                            ))
-                        )}
-                    </div>
+                            ))}
+                        </div>
+                    )}
                     {isBackToVisible && (
                         <button className="a-to-z-index-back-to" onClick={scrollToElement}>
                             <ChevronUpIcon />


### PR DESCRIPTION
- Added loading state with placeholders
- Added blank state for no results cta
- Misc CSS/JS cleanup

I unfortunately had to duplicate a few elements like `<div className="a-to-z-index-alphabet">` and `<div className="a-to-z-index-sections">` because of the placeholders AND how the "no results" section sits up into where the alphabet buttons would be. If you can think of a cleaner way to do this, we can definitely change this up!
