### PR TITLE
style(a-to-z-index): reduce size of letters on small screens

### DIFF
--- a/src/a-to-z/style.scss
+++ b/src/a-to-z/style.scss
@@ -222,12 +222,18 @@ button.a-to-z-index-alphabet-letter-button {
 	display: inline-block;
 	margin: -18px 0 0;
 	font-family: 'MontserratBlackStatic';
-	font-size: 140px;
+	font-size: 85px;
 	line-height: 1;
 	color: transparent;
 	text-transform: uppercase;
 	-webkit-text-stroke: 2px var(--wp--preset--color--smokey);
 	text-shadow: 4px 0px var(--wp--preset--color--orange);
+}
+
+@media screen and (min-width: 600px) {
+	.a-to-z-index-section-drop-cap-letter {
+		font-size: 140px;
+	}
 }
 
 .a-to-z-index-section-content {


### PR DESCRIPTION
Reduce the size of the drop cap letters in the main listing on smaller screens