### PR TITLE
chore(a-to-z-plugin): fix vulnerable packages with npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1955,9 +1955,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
-			"integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -1974,13 +1974,13 @@
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^3.0.3"
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
-			"integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2058,9 +2058,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
-			"integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+			"integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2583,9 +2583,9 @@
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -3165,37 +3165,38 @@
 			}
 		},
 		"node_modules/@paulirish/trace_engine": {
-			"version": "0.0.50",
-			"resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.50.tgz",
-			"integrity": "sha512-ktkbISnr0T9dkOxtnEadjYsbArMcvX2Wp8zwgyIP6KW0eOk2Oe2s49BY4v0qdE3uQdVv/GDdQ6MnoIFuYNJ9pg==",
+			"version": "0.0.53",
+			"resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.53.tgz",
+			"integrity": "sha512-PUl/vlfo08Oj804VI5nDPeSk9vyslnBlVzDDwFt8SUVxY8+KdGMkra/vrXjEEHe8gb7+RqVTfOIlGw0nyrEelA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
+				"legacy-javascript": "latest",
 				"third-party-web": "latest"
 			}
 		},
 		"node_modules/@pkgr/core": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.0.tgz",
-			"integrity": "sha512-vsJDAkYR6qCPu+ioGScGiMYR7LvZYIXh/dlQeviqoTWNCVfKTLYD/LkNWH4Mxsv2a5vpIRc77FN5DnmK1eBggQ==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
+			"integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://opencollective.com/unts"
+				"url": "https://opencollective.com/pkgr"
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.51.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
-			"integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+			"integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.51.1"
+				"playwright": "1.52.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -3787,9 +3788,9 @@
 			}
 		},
 		"node_modules/@types/babel__generator": {
-			"version": "7.6.8",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
-			"integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4304,9 +4305,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -4435,9 +4436,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -4474,9 +4475,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -4733,9 +4734,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.21.0.tgz",
-			"integrity": "sha512-NlYlnjtG/y68/SnRREv3UhDY/2tWH6qYTHcCXQHAQ7mVFFcpRshioBx2y1GF1JRVAprHWXC8KiTBrssPGr8/JA==",
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.25.0.tgz",
+			"integrity": "sha512-8Sf4pkH7/4pcKt/jOkVNLOoScypMOM2xEHtyiTE5tHgX4z7UZRNbXFKqJ9fxDDb/cniDdNyeG5QhOLIZbO7hlg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -4745,8 +4746,8 @@
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
 				"@babel/runtime": "7.25.7",
-				"@wordpress/browserslist-config": "^6.21.0",
-				"@wordpress/warning": "^3.21.0",
+				"@wordpress/browserslist-config": "^6.25.0",
+				"@wordpress/warning": "^3.25.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -4935,9 +4936,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-5.21.0.tgz",
-			"integrity": "sha512-b+6GV/DWZSqf4n9u72jwxo0uXiCkkoppaAOCuAKAzXxq//I38q3Sqg14WJjjINlLkuvIc+xMXHtZ66eHTRz8IA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.1.0.tgz",
+			"integrity": "sha512-5AC4M7jXQaSknrSiuBbUWJa00jYr6i3yABf93VFuVzy9QGZQTvupQo2/bi6uAZ98pDruniScrnJJq8UG6JsoJQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -4946,9 +4947,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.21.0.tgz",
-			"integrity": "sha512-8NTmCQMtL852d5+scnuayiHeIDzlWnNCrupJiyyIyAUZpk05E8PLOswQvvTpsiCgwKAKXlRTLuNGKkAXAX1nPA==",
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.25.0.tgz",
+			"integrity": "sha512-pJdhs1KJES46Z7/EFA4clmXlc+BBMlDrtFjoBX1FC5Lqh4RfJ1YD7VGdMSSuQpCF2iIrU4AijR31AZQ8NOy5mQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -4957,9 +4958,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.21.0.tgz",
-			"integrity": "sha512-LGt6ZCjy7BakglMY6FZqw3hGNgHipW8l+Dl+2K0eRPwe73tGGNA25NsInKOTJMSAaVsGrrfgr7XnyF8qqPM4Vg==",
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.25.0.tgz",
+			"integrity": "sha512-bAVve8ksBNfCcBq09IoTLCdF604UXtVh4Fb+/LBqyJc1kTTS02PsIv5aguSvCjcNSakQgvs7IJqEGJ2ZmP4JZg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -4981,9 +4982,9 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.21.0.tgz",
-			"integrity": "sha512-SeGRA7skkST9TB56yHeY8pNBN5iNdtz3bc2j9gSim7U73/BgbC4LZPVAK6NfRJlckhJHofp92PC9aExheWSJTQ==",
+			"version": "1.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.25.0.tgz",
+			"integrity": "sha512-M1jn4qH9iq1igLZ+sMQYNWp0P1tDgDsXF1iWWdqRn9wWcwHFn7iyDEEZ68uXzNvavkGyIHxZIoBcmKGeUA11/A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5003,17 +5004,17 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "22.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.7.0.tgz",
-			"integrity": "sha512-0696awnWdUbV8cmAyC/6GQ6xS6nfBXikfM157GlctG3ac42VRW2jR0Qw7sm+2KmD0o4uMc+fz4CHuTLkVYhNBw==",
+			"version": "22.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.11.0.tgz",
+			"integrity": "sha512-JxN4T7r0k9lePG1dDJ2bxyqc5zFtLeTY0Ns8EfU2G/QZsB6gvxGTLhK2u6csflswUt2vnJ3oCT5MbPfANJuLDg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "7.25.7",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.21.0",
-				"@wordpress/prettier-config": "^4.21.0",
+				"@wordpress/babel-preset-default": "^8.25.0",
+				"@wordpress/prettier-config": "^4.25.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
@@ -5093,9 +5094,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.21.0.tgz",
-			"integrity": "sha512-y5VFn//Tt7sASccwKGHkjLj3yHWSABiutEusTx2PJ1CzOJwTWldf5KDTnMqMciXf2In84ImV9dLyoI1pllJP0g==",
+			"version": "8.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.25.0.tgz",
+			"integrity": "sha512-X2YzKV1Pv5PC6QHqUp+FDlBgu7C+a2Yxdk6p4XDsTIjLV+I7eQuAdBUMzjyKSd1wN/Tx0x6Dr7/HmrV0ThRm1Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5111,13 +5112,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.21.0.tgz",
-			"integrity": "sha512-heTTSDh1THOa+9TnpPYZ07B7iZVstrPvfB5pYjOrnig3/DeYu1cgQpUJiwkvot6P+weFhhWSZoFXossItXQVTA==",
+			"version": "12.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.25.0.tgz",
+			"integrity": "sha512-YLKfgQl5ZW63XuJh24Mzv1yXIO4otTXg9fTbSsEAHhZI8KQL9VuFJgNQ4hE8lZV2Wbmy6Njh8q4TY05/oMJ3KA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.21.0",
+				"@wordpress/jest-console": "^8.25.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -5130,9 +5131,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.21.0.tgz",
-			"integrity": "sha512-g85tkbMvtSHluXZscNCyTQQ9ISg1zG0pgJZqY0DT57/gGrFyme6FZud68yTaUHFJvEyK3+8zbfcGIj7sN/i1dw==",
+			"version": "5.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.25.0.tgz",
+			"integrity": "sha512-wB35qxGlVkBx0GdoxDXjySMACHYgfrFacYcP6IkYHMu1e7/HU/Kz8ZW2g+4A+nea/SPO46V6xuSbayrYy6c+UQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5144,13 +5145,13 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.21.0.tgz",
-			"integrity": "sha512-sDSzaCV5efKSO8aBUgN/domZFM9BY9yh1qP7SIjOzSStVYGDNDdxdUJ4u3zm+shtR6aSLVozrfGf+Mb5+PN72w==",
+			"version": "5.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.25.0.tgz",
+			"integrity": "sha512-J9RK9R1cwiOBXC/iORi1Kz1i9VEASAv7OnERGxtHtbXFsPXq1cHDNJ3slwYGovUPjMOvfDNMjCgTWtM3MizEag==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^5.21.0",
+				"@wordpress/base-styles": "^6.1.0",
 				"autoprefixer": "^10.4.20"
 			},
 			"engines": {
@@ -5162,9 +5163,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.21.0.tgz",
-			"integrity": "sha512-UzM/ZtZAR7kLszn124bPa7PDlVT2cPgi+z0wyt95+c2Lg8aNz5O00L5Vxrjcql5gN36uPoQfXj+5CgG1XFiZEQ==",
+			"version": "4.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.25.0.tgz",
+			"integrity": "sha512-P18anKvMO9lEpr2827No0SFmeypX1A5Ce3DZ4NdNNnoJRGYkdlwRzwMpMoB9XpAQz5o45ystBrak2/OqzdBWLg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5176,25 +5177,25 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "30.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.14.0.tgz",
-			"integrity": "sha512-0u3ZH99Lsv50wDPUF6AYPluJ87mJnZdrVdH5BXTp1RBCEcAQh2cAlMPIdlyQUqCuBbprOwEhjtM4cbg2vCaUcQ==",
+			"version": "30.18.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.18.0.tgz",
+			"integrity": "sha512-NVtJYcmWjq57TDc0kStw0oeejpejH2KSJklOrDKf4Sah4gDQqy695COnHSVVoujCgUm6a5uv5+3mpujF08JsRA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.21.0",
-				"@wordpress/browserslist-config": "^6.21.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.21.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.21.0",
-				"@wordpress/eslint-plugin": "^22.7.0",
-				"@wordpress/jest-preset-default": "^12.21.0",
-				"@wordpress/npm-package-json-lint-config": "^5.21.0",
-				"@wordpress/postcss-plugins-preset": "^5.21.0",
-				"@wordpress/prettier-config": "^4.21.0",
-				"@wordpress/stylelint-config": "^23.13.0",
+				"@wordpress/babel-preset-default": "^8.25.0",
+				"@wordpress/browserslist-config": "^6.25.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.25.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.25.0",
+				"@wordpress/eslint-plugin": "^22.11.0",
+				"@wordpress/jest-preset-default": "^12.25.0",
+				"@wordpress/npm-package-json-lint-config": "^5.25.0",
+				"@wordpress/postcss-plugins-preset": "^5.25.0",
+				"@wordpress/prettier-config": "^4.25.0",
+				"@wordpress/stylelint-config": "^23.17.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",
@@ -5257,9 +5258,9 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.13.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.13.0.tgz",
-			"integrity": "sha512-oxWnf61RHoNntBxobwcnSU32kqfBTRvtKaRSidiHJfBXM+AWU74ZJ0Ro6bcv5cxHAPdEgtdSa95g2hOqJusYoA==",
+			"version": "23.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.17.0.tgz",
+			"integrity": "sha512-FYA2pEJWLfC3g08rmBmEY6frRD45NLBpLX1W4tLgPDFwC21WHr9aEvIdPS4YF+1/kNwRGWdkTITcR2Lq5dZ4wg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5272,13 +5273,14 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"stylelint": "^16.8.2"
+				"stylelint": "^16.8.2",
+				"stylelint-scss": "^6.4.0"
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.21.0.tgz",
-			"integrity": "sha512-KkVhXK9s5Ftly2Z0BJfQR7m3Z4WB+8/+w0Tj86Cztz3NJk3iFF51Tes5zAD8GhDJ4SelwGW5ghALV51coTjrWA==",
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.25.0.tgz",
+			"integrity": "sha512-Pp4+1zgY6wDqiGPpb33+B7YplujkFyMVmi2VDBbJcy/OEXNU/cowfjYuGxgyQpJlCpKnrmVYV+snowZ3Iytk0g==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5638,18 +5640,20 @@
 			"license": "MIT"
 		},
 		"node_modules/array-includes": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
-			"integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+			"integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
 				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-object-atoms": "^1.0.0",
-				"get-intrinsic": "^1.2.4",
-				"is-string": "^1.0.7"
+				"es-abstract": "^1.24.0",
+				"es-object-atoms": "^1.1.1",
+				"get-intrinsic": "^1.3.0",
+				"is-string": "^1.1.1",
+				"math-intrinsics": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -6477,20 +6481,20 @@
 			}
 		},
 		"node_modules/cacheable": {
-			"version": "1.8.9",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.9.tgz",
-			"integrity": "sha512-FicwAUyWnrtnd4QqYAoRlNs44/a1jTL7XDKqm5gJ90wz1DQPlC7U2Rd1Tydpv+E7WAr4sQHuw8Q8M3nZMAyecQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.9.0.tgz",
+			"integrity": "sha512-8D5htMCxPDUULux9gFzv30f04Xo3wCnik0oOxKoRTPIBoqA7HtOcJ87uBhQTs3jCfZZTrUBGsYIZOgE0ZRgMAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hookified": "^1.7.1",
-				"keyv": "^5.3.1"
+				"hookified": "^1.8.2",
+				"keyv": "^5.3.3"
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.2.tgz",
-			"integrity": "sha512-Lji2XRxqqa5Wg+CHLVfFKBImfJZ4pCSccu9eVWK6w4c2SDFLd8JAn1zqTuSFnsxb7ope6rMsnIHfp+eBbRBRZQ==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.3.tgz",
+			"integrity": "sha512-Rwu4+nXI9fqcxiEHtbkvoes2X+QfkTRo1TMkPfwzipGsJlJO/z69vqB4FNl9xJ3xCpAcbkvmEabZfPzrwN3+gQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6755,9 +6759,9 @@
 			}
 		},
 		"node_modules/chrome-launcher": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.1.2.tgz",
-			"integrity": "sha512-YclTJey34KUm5jB1aEJCq807bSievi7Nb/TU4Gu504fUYi3jw3KCIaH6L7nFWQhdEgH3V+wCh+kKD1P5cXnfxw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.0.tgz",
+			"integrity": "sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -6767,7 +6771,7 @@
 				"lighthouse-logger": "^2.0.1"
 			},
 			"bin": {
-				"print-chrome-path": "bin/print-chrome-path.js"
+				"print-chrome-path": "bin/print-chrome-path.cjs"
 			},
 			"engines": {
 				"node": ">=12.13.0"
@@ -7219,9 +7223,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.41.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
-			"integrity": "sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==",
+			"version": "3.42.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.42.0.tgz",
+			"integrity": "sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -7743,9 +7747,9 @@
 			"license": "MIT"
 		},
 		"node_modules/debug": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7805,9 +7809,9 @@
 			"license": "MIT"
 		},
 		"node_modules/dedent": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
-			"integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+			"integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -8042,9 +8046,9 @@
 			"license": "MIT"
 		},
 		"node_modules/devtools-protocol": {
-			"version": "0.0.1436416",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1436416.tgz",
-			"integrity": "sha512-iGLhz2WOrlBLcTcoVsFy5dPPUqILG6cc8MITYd5lV6i38gWG14bMXRH/d8G5KITrWHBnbsOnWHfc9Qs4/jej9Q==",
+			"version": "0.0.1467305",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1467305.tgz",
+			"integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -8365,9 +8369,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.23.9",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
-			"integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
+			"version": "1.24.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+			"integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8375,18 +8379,18 @@
 				"arraybuffer.prototype.slice": "^1.0.4",
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
+				"call-bound": "^1.0.4",
 				"data-view-buffer": "^1.0.2",
 				"data-view-byte-length": "^1.0.2",
 				"data-view-byte-offset": "^1.0.1",
 				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
+				"es-object-atoms": "^1.1.1",
 				"es-set-tostringtag": "^2.1.0",
 				"es-to-primitive": "^1.3.0",
 				"function.prototype.name": "^1.1.8",
-				"get-intrinsic": "^1.2.7",
-				"get-proto": "^1.0.0",
+				"get-intrinsic": "^1.3.0",
+				"get-proto": "^1.0.1",
 				"get-symbol-description": "^1.1.0",
 				"globalthis": "^1.0.4",
 				"gopd": "^1.2.0",
@@ -8398,21 +8402,24 @@
 				"is-array-buffer": "^3.0.5",
 				"is-callable": "^1.2.7",
 				"is-data-view": "^1.0.2",
+				"is-negative-zero": "^2.0.3",
 				"is-regex": "^1.2.1",
+				"is-set": "^2.0.3",
 				"is-shared-array-buffer": "^1.0.4",
 				"is-string": "^1.1.1",
 				"is-typed-array": "^1.1.15",
-				"is-weakref": "^1.1.0",
+				"is-weakref": "^1.1.1",
 				"math-intrinsics": "^1.1.0",
-				"object-inspect": "^1.13.3",
+				"object-inspect": "^1.13.4",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.7",
 				"own-keys": "^1.0.1",
-				"regexp.prototype.flags": "^1.5.3",
+				"regexp.prototype.flags": "^1.5.4",
 				"safe-array-concat": "^1.1.3",
 				"safe-push-apply": "^1.0.0",
 				"safe-regex-test": "^1.1.0",
 				"set-proto": "^1.0.0",
+				"stop-iteration-iterator": "^1.1.0",
 				"string.prototype.trim": "^1.2.10",
 				"string.prototype.trimend": "^1.0.9",
 				"string.prototype.trimstart": "^1.0.8",
@@ -8421,7 +8428,7 @@
 				"typed-array-byte-offset": "^1.0.4",
 				"typed-array-length": "^1.0.7",
 				"unbox-primitive": "^1.1.0",
-				"which-typed-array": "^1.1.18"
+				"which-typed-array": "^1.1.19"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8954,9 +8961,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -8991,9 +8998,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -9074,14 +9081,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.5.tgz",
-			"integrity": "sha512-IKKP8R87pJyMl7WWamLgPkloB16dagPIdd2FjBDbyRYPKo93wS/NbCOPh6gH+ieNLC+XZrhJt/kWj0PS/DFdmg==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.1.tgz",
+			"integrity": "sha512-9dF+KuU/Ilkq27A8idRP7N2DH8iUR6qXcjF3FR2wETY21PZdBrIjwCau8oboyGj9b7etWmTGEeM8e7oOed6ZWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"prettier-linter-helpers": "^1.0.0",
-				"synckit": "^0.10.2"
+				"synckit": "^0.11.7"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -9105,9 +9112,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react": {
-			"version": "7.37.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
-			"integrity": "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==",
+			"version": "7.37.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+			"integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9121,7 +9128,7 @@
 				"hasown": "^2.0.2",
 				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
 				"minimatch": "^3.1.2",
-				"object.entries": "^1.1.8",
+				"object.entries": "^1.1.9",
 				"object.fromentries": "^2.0.8",
 				"object.values": "^1.2.1",
 				"prop-types": "^15.8.1",
@@ -10708,9 +10715,9 @@
 			}
 		},
 		"node_modules/hookified": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.8.1.tgz",
-			"integrity": "sha512-GrO2l93P8xCWBSTBX9l2BxI78VU/MAAYag+pG8curS3aBGy0++ZlxrQ7PdUOUVMbn5BwkGb6+eRrnf43ipnFEA==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.9.1.tgz",
+			"integrity": "sha512-u3pxtGhKjcSXnGm1CX6aXS9xew535j3lkOCegbA6jdyh0BaAjTbXI4aslKstCr6zUNtoCxFGFKwjbSHdGrMB8g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10922,9 +10929,9 @@
 			}
 		},
 		"node_modules/http-proxy-middleware": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-			"integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+			"integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11556,6 +11563,19 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
 			"integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-negative-zero": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12532,9 +12552,9 @@
 			}
 		},
 		"node_modules/jest-snapshot/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -12875,9 +12895,9 @@
 			}
 		},
 		"node_modules/known-css-properties": {
-			"version": "0.35.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
-			"integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
+			"integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12922,6 +12942,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/legacy-javascript": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
+			"integrity": "sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -12957,19 +12984,19 @@
 			}
 		},
 		"node_modules/lighthouse": {
-			"version": "12.5.1",
-			"resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-12.5.1.tgz",
-			"integrity": "sha512-ooOIqtBxOEnuX3yKtc8WiMPI/fPqHtXHaXU4ey87icRcY5I2B9+imk8i6U7duIO+yrU0WwbIwhmCs8s/FFNRgA==",
+			"version": "12.6.1",
+			"resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-12.6.1.tgz",
+			"integrity": "sha512-85WDkjcXAVdlFem9Y6SSxqoKiz/89UsDZhLpeLJIsJ4LlHxw047XTZhlFJmjYCB7K5S1erSBAf5cYLcfyNbH3A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@paulirish/trace_engine": "0.0.50",
+				"@paulirish/trace_engine": "0.0.53",
 				"@sentry/node": "^7.0.0",
 				"axe-core": "^4.10.3",
-				"chrome-launcher": "^1.1.2",
+				"chrome-launcher": "^1.2.0",
 				"configstore": "^5.0.1",
 				"csp_evaluator": "1.1.5",
-				"devtools-protocol": "0.0.1436416",
+				"devtools-protocol": "0.0.1467305",
 				"enquirer": "^2.3.6",
 				"http-link-header": "^1.1.1",
 				"intl-messageformat": "^10.5.3",
@@ -12982,11 +13009,11 @@
 				"metaviewport-parser": "0.3.0",
 				"open": "^8.4.0",
 				"parse-cache-control": "1.0.1",
-				"puppeteer-core": "^24.4.0",
+				"puppeteer-core": "^24.10.0",
 				"robots-parser": "^3.0.1",
 				"semver": "^5.3.0",
 				"speedline-core": "^1.4.3",
-				"third-party-web": "^0.26.5",
+				"third-party-web": "^0.26.6",
 				"tldts-icann": "^6.1.16",
 				"ws": "^7.0.0",
 				"yargs": "^17.3.1",
@@ -12998,7 +13025,7 @@
 				"smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
 			},
 			"engines": {
-				"node": ">=18.16"
+				"node": ">=18.20"
 			}
 		},
 		"node_modules/lighthouse-logger": {
@@ -13037,17 +13064,17 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lighthouse/node_modules/@puppeteer/browsers": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.8.0.tgz",
-			"integrity": "sha512-yTwt2KWRmCQAfhvbCRjebaSX8pV1//I0Y3g+A7f/eS7gf0l4eRJoUCvcYdVtboeU4CTOZQuqYbZNS8aBYb8ROQ==",
+			"version": "2.10.5",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
+			"integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"debug": "^4.4.0",
+				"debug": "^4.4.1",
 				"extract-zip": "^2.0.1",
 				"progress": "^2.0.3",
 				"proxy-agent": "^6.5.0",
-				"semver": "^7.7.1",
+				"semver": "^7.7.2",
 				"tar-fs": "^3.0.8",
 				"yargs": "^17.7.2"
 			},
@@ -13059,9 +13086,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/@puppeteer/browsers/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -13072,27 +13099,27 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.4.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.4.0.tgz",
-			"integrity": "sha512-eFw66gCnWo0X8Hyf9KxxJtms7a61NJVMiSaWfItsFPzFBsjsWdmcNlBdsA1WVwln6neoHhsG+uTVesKmTREn/g==",
+			"version": "24.10.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.10.0.tgz",
+			"integrity": "sha512-xX0QJRc8t19iAwRDsAOR38Q/Zx/W6WVzJCEhKCAwp2XMsaWqfNtQ+rBfQW9PlF+Op24d7c8Zlgq9YNmbnA7hdQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.8.0",
-				"chromium-bidi": "2.1.2",
-				"debug": "^4.4.0",
-				"devtools-protocol": "0.0.1413902",
+				"@puppeteer/browsers": "2.10.5",
+				"chromium-bidi": "5.1.0",
+				"debug": "^4.4.1",
+				"devtools-protocol": "0.0.1452169",
 				"typed-query-selector": "^2.12.0",
-				"ws": "^8.18.1"
+				"ws": "^8.18.2"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/chromium-bidi": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-2.1.2.tgz",
-			"integrity": "sha512-vtRWBK2uImo5/W2oG6/cDkkHSm+2t6VHgnj+Rcwhb0pP74OoUb4GipyRX/T/y39gYQPhioP0DPShn+A7P6CHNw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-5.1.0.tgz",
+			"integrity": "sha512-9MSRhWRVoRPDG0TgzkHrshFSJJNZzfY5UFqUMuksg7zL1yoZIZ3jLB0YAgHclbiAxPI86pBnwDX1tbzoiV8aFw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -13104,16 +13131,16 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1413902",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1413902.tgz",
-			"integrity": "sha512-yRtvFD8Oyk7C9Os3GmnFZLu53yAfsnyw1s+mLmHHUK0GQEc9zthHWvS1r67Zqzm5t7v56PILHIVZ7kmFMaL2yQ==",
+			"version": "0.0.1452169",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1452169.tgz",
+			"integrity": "sha512-FOFDVMGrAUNp0dDKsAU1TorWJUx2JOU1k9xdgBKKJF3IBh/Uhl2yswG5r3TEAOrCiGY2QRp1e6LVDQrCsTKO4g==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-			"version": "8.18.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-			"integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+			"version": "8.18.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+			"integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13165,9 +13192,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/zod": {
-			"version": "3.24.2",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-			"integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+			"version": "3.25.51",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.51.tgz",
+			"integrity": "sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -13389,9 +13416,9 @@
 			}
 		},
 		"node_modules/make-dir/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -13575,9 +13602,9 @@
 			"license": "MIT"
 		},
 		"node_modules/marky": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
-			"integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+			"integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -14082,9 +14109,9 @@
 			}
 		},
 		"node_modules/normalize-package-data/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -14172,9 +14199,9 @@
 			"license": "MIT"
 		},
 		"node_modules/npm-package-json-lint/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -15000,14 +15027,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.51.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
-			"integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+			"integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.51.1"
+				"playwright-core": "1.52.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -15020,9 +15047,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.51.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
-			"integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+			"integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -17738,6 +17765,20 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/stop-iteration-iterator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+			"integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"internal-slot": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/streamx": {
 			"version": "2.22.0",
 			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
@@ -18018,9 +18059,9 @@
 			}
 		},
 		"node_modules/stylelint": {
-			"version": "16.17.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.17.0.tgz",
-			"integrity": "sha512-I9OwVIWRMqVm2Br5iTbrfSqGRPWQUlvm6oXO1xZuYYu0Gpduy67N8wXOZv15p6E/JdlZiAtQaIoLKZEWk5hrjw==",
+			"version": "16.20.0",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.20.0.tgz",
+			"integrity": "sha512-B5Myu9WRxrgKuLs3YyUXLP2H0mrbejwNxPmyADlACWwFsrL8Bmor/nTSh4OMae5sHjOz6gkSeccQH34gM4/nAw==",
 			"dev": true,
 			"funding": [
 				{
@@ -18044,18 +18085,18 @@
 				"cosmiconfig": "^9.0.0",
 				"css-functions-list": "^3.2.3",
 				"css-tree": "^3.1.0",
-				"debug": "^4.3.7",
+				"debug": "^4.4.1",
 				"fast-glob": "^3.3.3",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^10.0.7",
+				"file-entry-cache": "^10.1.0",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.3.1",
-				"ignore": "^7.0.3",
+				"ignore": "^7.0.4",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.35.0",
+				"known-css-properties": "^0.36.0",
 				"mathml-tag-names": "^2.1.3",
 				"meow": "^13.2.0",
 				"micromatch": "^4.0.8",
@@ -18128,16 +18169,16 @@
 			}
 		},
 		"node_modules/stylelint-scss": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.11.1.tgz",
-			"integrity": "sha512-e4rYo0UY+BIMtGeGanghrvHTjcryxgZbyFxUedp8dLFqC4P70aawNdYjRrQxbnKhu3BNr4+lt5e/53tcKXiwFA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.0.tgz",
+			"integrity": "sha512-U7CKhi1YNkM1pXUXl/GMUXi8xKdhl4Ayxdyceie1nZ1XNIdaUgMV6OArpooWcDzEggwgYD0HP/xIgVJo9a655w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"css-tree": "^3.0.1",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.35.0",
-				"mdn-data": "^2.15.0",
+				"known-css-properties": "^0.36.0",
+				"mdn-data": "^2.21.0",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.6",
 				"postcss-selector-parser": "^7.1.0",
@@ -18151,9 +18192,9 @@
 			}
 		},
 		"node_modules/stylelint-scss/node_modules/mdn-data": {
-			"version": "2.18.0",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.18.0.tgz",
-			"integrity": "sha512-gtCy1yim/vpHF/tq3B4Z43x3zKWpYeb4IM3d/Mf4oMYcNuoXOYEaqtoFlLHw9zd7+WNN3jNh6/WXyUrD3OIiwQ==",
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.21.0.tgz",
+			"integrity": "sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -18172,9 +18213,9 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/@csstools/media-query-list-parser": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.2.tgz",
-			"integrity": "sha512-EUos465uvVvMJehckATTlNqGj4UJWkTmdWuDMjqvSUkjGpmOyFZBVwb4knxCm/k2GMTXY+c/5RkdndzFYWeX5A==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
+			"integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -18191,8 +18232,8 @@
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.4",
-				"@csstools/css-tokenizer": "^3.0.3"
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
 		"node_modules/stylelint/node_modules/@csstools/selector-specificity": {
@@ -18260,25 +18301,25 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
-			"version": "10.0.7",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.0.7.tgz",
-			"integrity": "sha512-txsf5fu3anp2ff3+gOJJzRImtrtm/oa9tYLN0iTuINZ++EyVR/nRrg2fKYwvG/pXDofcrvvb0scEbX3NyW/COw==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.0.tgz",
+			"integrity": "sha512-Et/ex6smi3wOOB+n5mek+Grf7P2AxZR5ueqRUvAAn4qkyatXi3cUC1cuQXVkX0VlzBVsN4BkWJFmY/fYiRTdww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^6.1.7"
+				"flat-cache": "^6.1.9"
 			}
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
-			"version": "6.1.7",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.7.tgz",
-			"integrity": "sha512-qwZ4xf1v1m7Rc9XiORly31YaChvKt6oNVHuqqZcoED/7O+ToyNVGobKsIAopY9ODcWpEDKEBAbrSOCBHtNQvew==",
+			"version": "6.1.9",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.9.tgz",
+			"integrity": "sha512-DUqiKkTlAfhtl7g78IuwqYM+YqvT+as0mY+EVk6mfimy19U79pJCzDZQsnqk3Ou/T6hFXWLGbwbADzD/c8Tydg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cacheable": "^1.8.9",
+				"cacheable": "^1.9.0",
 				"flatted": "^3.3.3",
-				"hookified": "^1.7.1"
+				"hookified": "^1.8.2"
 			}
 		},
 		"node_modules/stylelint/node_modules/global-modules": {
@@ -18310,9 +18351,9 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/ignore": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
-			"integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -18530,20 +18571,19 @@
 			"license": "MIT"
 		},
 		"node_modules/synckit": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.10.3.tgz",
-			"integrity": "sha512-R1urvuyiTaWfeCggqEvpDJwAlDVdsT9NM+IP//Tk2x7qHCkSvBk/fwFgw/TLAHzZlrAnnazMcRw0ZD8HlYFTEQ==",
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+			"integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@pkgr/core": "^0.2.0",
-				"tslib": "^2.8.1"
+				"@pkgr/core": "^0.2.4"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://opencollective.com/unts"
+				"url": "https://opencollective.com/synckit"
 			}
 		},
 		"node_modules/table": {
@@ -18598,9 +18638,9 @@
 			}
 		},
 		"node_modules/tar-fs": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-			"integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+			"integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18794,9 +18834,9 @@
 			"license": "MIT"
 		},
 		"node_modules/third-party-web": {
-			"version": "0.26.5",
-			"resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.26.5.tgz",
-			"integrity": "sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==",
+			"version": "0.26.6",
+			"resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.26.6.tgz",
+			"integrity": "sha512-GsjP92xycMK8qLTcQCacgzvffYzEqe29wyz3zdKVXlfRD5Kz1NatCTOZEeDaSd6uCZXvGd2CNVtQ89RNIhJWvA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -18815,20 +18855,20 @@
 			"license": "MIT"
 		},
 		"node_modules/tldts-core": {
-			"version": "6.1.85",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.85.tgz",
-			"integrity": "sha512-DTjUVvxckL1fIoPSb3KE7ISNtkWSawZdpfxGxwiIrZoO6EbHVDXXUIlIuWympPaeS+BLGyggozX/HTMsRAdsoA==",
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tldts-icann": {
-			"version": "6.1.85",
-			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-6.1.85.tgz",
-			"integrity": "sha512-LIL8koGz5n2ni5wym7qw5vjeZxCgh5uI0Vs4LQu6M8k1IoknMttui/WTVI58jXBqRRSx76IniSJdeZDVFdALdw==",
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-6.1.86.tgz",
+			"integrity": "sha512-NFxmRT2lAEMcCOBgeZ0NuM0zsK/xgmNajnY6n4S1mwAKocft2s2ise1O3nQxrH3c+uY6hgHUV9GGNVp7tUE4Sg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^6.1.85"
+				"tldts-core": "^6.1.86"
 			}
 		},
 		"node_modules/tmpl": {


### PR DESCRIPTION
This does not include any fixes that will cause breaking changes (as alerted by `npm audit`)