### PR TITLE
fix(input-search): fix misaligned search cancel button on Safari

### DIFF
--- a/src/a-to-z/style.scss
+++ b/src/a-to-z/style.scss
@@ -8,13 +8,13 @@
 // MOVE TO UTKWDS
 
 @font-face {
-	font-family: 'MontserratBlackStatic'; 
-	src: url('MontserratBlackStatic.ttf');
+	font-family: "MontserratBlackStatic";
+	src: url("MontserratBlackStatic.ttf");
 }
 
 $input-border-color: #949494;
 $input-focus-border-color: #1a73c5;
-$focus-ring-color: rgba(26, 115, 197, 0.30);
+$focus-ring-color: rgba(26, 115, 197, 0.3);
 $form-select-bg-size: 16px 16px;
 $form-select-padding-x: 15px;
 $input-padding-x: 15px;
@@ -32,36 +32,36 @@ $input-padding-x: 15px;
 // MOVE TO UTKWDS
 
 label {
-    font-size: 1rem;
+	font-size: 1rem;
 }
 
 // Update UTKWDS theme file to this padding
 .form-floating {
-    width: 100%;
+	width: 100%;
 
-    input[type="search"] {
-        --bs-form-search-bg-img: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-search' viewBox='0 0 16 16'%3E%3Cpath d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0'/%3E%3C/svg%3E");
-        padding-right: 45px;
-        background-color: var(--bs-body-bg);
-        background-image: var(--bs-form-search-bg-img), var(--bs-form-search-bg-icon, none);
-        background-repeat: no-repeat;
-        background-position: right $form-select-padding-x center;
-        background-size: $form-select-bg-size;
+	input[type="search"] {
+		--bs-form-search-bg-img: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-search' viewBox='0 0 16 16'%3E%3Cpath d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0'/%3E%3C/svg%3E");
+		padding-right: 45px;
+		background-color: var(--bs-body-bg);
+		background-image: var(--bs-form-search-bg-img),
+			var(--bs-form-search-bg-icon, none);
+		background-repeat: no-repeat;
+		background-position: right $form-select-padding-x center;
+		background-size: $form-select-bg-size;
 
-        &::-webkit-search-cancel-button {
-					position: relative;
-					-webkit-appearance: none;
-					width: 16px;
-					height: 16px;
-					top: 50%;
-					right: -10px;
-					padding-right: 7px;
-					background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18' fill='none'%3E%3Cpath d='M2.37414 3.30934C2.15816 3.09336 2.15816 2.7432 2.37414 2.52722C2.59012 2.31124 2.94029 2.31124 3.15627 2.52722L8.8487 8.21966L14.5411 2.52722C14.7571 2.31124 15.1073 2.31124 15.3233 2.52722C15.5392 2.7432 15.5392 3.09336 15.3233 3.30934L9.63083 9.00178L15.3233 14.6942C15.5392 14.9102 15.5392 15.2604 15.3233 15.4763C15.1073 15.6923 14.7571 15.6923 14.5411 15.4763L8.84871 9.78391L3.15627 15.4763C2.94029 15.6923 2.59012 15.6923 2.37414 15.4763C2.15816 15.2604 2.15816 14.9102 2.37414 14.6942L8.06658 9.00178L2.37414 3.30934Z' fill='%234B4B4B'/%3E%3C/svg%3E");
-					background-repeat: no-repeat;
-					border-right: 1px solid #D9D9D9;
-					transform: translateY(-50%);
-        }
-    }
+		&::-webkit-search-cancel-button {
+			position: relative;
+			-webkit-appearance: none;
+			width: 16px;
+			height: 16px;
+			right: -10px;
+			padding-right: 7px;
+			background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18' fill='none'%3E%3Cpath d='M2.37414 3.30934C2.15816 3.09336 2.15816 2.7432 2.37414 2.52722C2.59012 2.31124 2.94029 2.31124 3.15627 2.52722L8.8487 8.21966L14.5411 2.52722C14.7571 2.31124 15.1073 2.31124 15.3233 2.52722C15.5392 2.7432 15.5392 3.09336 15.3233 3.30934L9.63083 9.00178L15.3233 14.6942C15.5392 14.9102 15.5392 15.2604 15.3233 15.4763C15.1073 15.6923 14.7571 15.6923 14.5411 15.4763L8.84871 9.78391L3.15627 15.4763C2.94029 15.6923 2.59012 15.6923 2.37414 15.4763C2.15816 15.2604 2.15816 14.9102 2.37414 14.6942L8.06658 9.00178L2.37414 3.30934Z' fill='%234B4B4B'/%3E%3C/svg%3E");
+			background-repeat: no-repeat;
+			border-right: 1px solid #d9d9d9;
+			transform: translateY(-50%);
+		}
+	}
 }
 
 .placeholder {
@@ -69,8 +69,8 @@ label {
 	border-radius: 4px;
 
 	&-lg {
-    min-height: 32px;
-  }
+		min-height: 32px;
+	}
 }
 
 .a-to-z-container-banner {
@@ -80,19 +80,19 @@ label {
 // END MOVE TO UTKWDS
 
 .a-to-z-index {
-  margin-top: -150px !important;
-  background: #fff;
+	margin-top: -150px !important;
+	background: #fff;
 }
 
 .a-to-z-index-input {
-  padding: 20px 20px 0;
+	padding: 20px 20px 0;
 }
 
 @media screen and (min-width: 600px) {
-  .a-to-z-index-input {
-    align-items: center;
-    padding: 30px 30px 0;
-  }
+	.a-to-z-index-input {
+		align-items: center;
+		padding: 30px 30px 0;
+	}
 }
 
 .a-to-z-index-alphabet {
@@ -112,15 +112,15 @@ label {
 }
 
 @media screen and (min-width: 600px) {
-  .a-to-z-index-alphabet {
+	.a-to-z-index-alphabet {
 		gap: 10px;
-    padding: 25px 10px 30px;
+		padding: 25px 10px 30px;
 		border-bottom: none;
 
 		.admin-bar & {
 			top: 32px;
 		}
-  }
+	}
 }
 
 .a-to-z-index-alphabet-letter {
@@ -146,7 +146,7 @@ label {
 	&:hover {
 		color: var(--wp--preset--color--white);
 		text-decoration: none;
-    background-color: var(--wp--custom--color--river);
+		background-color: var(--wp--custom--color--river);
 	}
 }
 
@@ -177,14 +177,14 @@ button.a-to-z-index-alphabet-letter-button {
 
 .a-to-z-index-no-results-content {
 	max-width: 750px;
-  margin: 0 auto;
+	margin: 0 auto;
 	text-align: center;
-  
-  h2 {
+
+	h2 {
 		margin: 0;
-    font-weight: var(--wp--custom--font-weight--black);
-    line-height: var(--wp--custom--line-height--heading);
-  }	
+		font-weight: var(--wp--custom--font-weight--black);
+		line-height: var(--wp--custom--line-height--heading);
+	}
 }
 
 .a-to-z-index-section {
@@ -196,11 +196,10 @@ button.a-to-z-index-alphabet-letter-button {
 	.a-to-z-index-section {
 		display: flex;
 		margin: 0 0 100px;
-	}	
+	}
 }
 
 .a-to-z-index-section-drop-cap {
-	
 }
 
 @media screen and (min-width: 600px) {
@@ -208,13 +207,13 @@ button.a-to-z-index-alphabet-letter-button {
 		width: 200px;
 		flex-shrink: 0;
 		text-align: right;
-	}	
+	}
 }
 
 .a-to-z-index-section-drop-cap-letter {
 	position: relative;
 	display: inline-block;
-	font-family: 'MontserratBlackStatic';
+	font-family: "MontserratBlackStatic";
 	font-size: 85px;
 	line-height: 1;
 	color: transparent;
@@ -241,7 +240,7 @@ button.a-to-z-index-alphabet-letter-button {
 		padding: 0 0 65px 65px;
 		border-top: none;
 		border-left: 4px solid var(--wp--preset--color--orange);
-	}	
+	}
 }
 
 .a-to-z-index-section-list {
@@ -257,25 +256,25 @@ button.a-to-z-index-alphabet-letter-button {
 }
 
 .a-to-z-index-back-to {
-  position: fixed;
-  align-items: center;
-  justify-content: center;
-  width: 58px;
-  height: 58px;
-  right: 20px;
-  bottom: 20px;
-  color: #fff;
-  background-color: #1a73c5;
-  border: none;
-  border-radius: 4px;
-  z-index: 1;
+	position: fixed;
+	align-items: center;
+	justify-content: center;
+	width: 58px;
+	height: 58px;
+	right: 20px;
+	bottom: 20px;
+	color: #fff;
+	background-color: #1a73c5;
+	border: none;
+	border-radius: 4px;
+	z-index: 1;
 
-  &:hover {
-    background-color: #0056a5;
-  }
+	&:hover {
+		background-color: #0056a5;
+	}
 
-  svg {
-    width: 28px;
-    height: 28px;
-  }
+	svg {
+		width: 28px;
+		height: 28px;
+	}
 }


### PR DESCRIPTION
I added "format on save" working on the PHP formatting, so I accidentally pushed _a lot_ of changes. The main change was removing the `top: 50%;` property.

Not entirely sure why that wasn't doing anything on Chrome. Maybe double check my sanity on that?

Before:
<img width="211" alt="Screenshot 2025-06-26 at 4 01 40 PM" src="https://github.com/user-attachments/assets/91e09b20-7d43-452f-9342-de45661f00f7" />

After:
<img width="178" alt="Screenshot 2025-06-26 at 4 01 53 PM" src="https://github.com/user-attachments/assets/471d1b81-e9fc-40ca-87b0-69740f639f0f" />